### PR TITLE
[codex] Add portfolio README and polish site metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
+# Shrut Prajapati | Analytics Portfolio
+
+A professional portfolio website for Shrut Prajapati, a data analytics and business intelligence professional focused on turning complex data into practical insights. The site highlights analytics experience, technical skills, selected projects, certifications, areas of interest, and contact pathways in a lightweight static web experience.
+
+## Portfolio Overview
+
+This portfolio is designed as a central profile for analytics, data science, and business intelligence opportunities. It presents Shrut's background across healthcare revenue cycle analytics, financial services, enterprise BI, predictive modeling, and data visualization.
+
+Visitors can quickly review:
+
+- Professional summary, education, internship, and work experience
+- Data analytics, machine learning, SQL, Python, R, Tableau, and Power BI skills
+- Featured portfolio projects with direct GitHub repository links
+- Areas of interest including cloud computing, NLP, machine learning, parallel computing, model deployment, and analytics storytelling
+- Contact information and social profile links
+
+## Tech Stack
+
+- **Frontend:** HTML5, CSS3, JavaScript
+- **Frameworks and libraries:** Bootstrap, Bootstrap Icons, AOS, Typed.js, PureCounter, GLightbox, Isotope, Swiper
+- **Design foundation:** BootstrapMade-style static portfolio template customized for an analytics profile
+- **Hosting target:** GitHub Pages or any static web host
+- **Forms:** Formspree-powered contact form
+
+## Local Run Instructions
+
+This is a static website, so no build step is required.
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/Shrut1261/analyst.git
+   cd analyst
+   ```
+
+2. Start a local static server:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+3. Open the portfolio in a browser:
+
+   ```text
+   http://localhost:8000
+   ```
+
+You can also open `index.html` directly in a browser, but a local server more closely matches production behavior for linked assets and scripts.
+
+## Featured Projects
+
+- **NASA Metadata Analysis:** Explores NASA metadata to identify structure, patterns, and useful signals for analysis.
+- **Predicting Alumni Giving Rates:** Uses machine learning to model alumni giving behavior and support higher education fundraising insights.
+- **Twitter Data Analysis:** Examines social media trends and sentiment patterns from Twitter data.
+- **Orange Data Analysis:** Demonstrates data mining workflows with Orange for exploratory and predictive analysis.
+- **Tableau Dashboard:** Presents interactive dashboarding and visual storytelling work.
+- **20 Newsgroups NLP:** Applies text classification and natural language processing techniques to the 20 Newsgroups dataset.
+- **Behavior Analysis:** Analyzes user behavior data to uncover patterns and decision-making insights.
+- **Credit Card Churn Prediction:** Builds a machine learning workflow for identifying customers at risk of churn.
+
+## Upgrade Roadmap
+
+- Improve SEO metadata, Open Graph tags, and structured profile descriptions.
+- Refine portfolio filters so each project maps cleanly to visible filter categories.
+- Expand project cards with stronger business context, tools used, and measurable outcomes.
+- Normalize image filenames and asset paths to reduce case-sensitivity issues on static hosts.
+- Add accessibility improvements such as descriptive image alt text and clearer social-link labels.
+- Add a lightweight validation workflow for HTML, broken links, and static asset availability.
+- Consider moving repeated inline styles into CSS for easier long-term maintenance.
+
+## Repository Notes
+
+- Primary page: `index.html`
+- Main stylesheet: `assets/css/main.css`
+- Main script: `assets/js/main.js`
+- Portfolio images: `assets/img/masonry-portfolio/`
 

--- a/index.html
+++ b/index.html
@@ -5,9 +5,18 @@
   <link rel="stylesheet" href="/Shrut-Portfolio/assets/css/css/style.css">
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-  <title> Portfolio </title>
-  <meta content="" name="description">
-  <meta content="" name="keywords">
+  <title>Shrut Prajapati | Data Analytics Portfolio</title>
+  <meta content="Shrut Prajapati's data analytics portfolio featuring machine learning, SQL, Python, Power BI, Tableau, NLP, forecasting, and business intelligence projects." name="description">
+  <meta content="Shrut Prajapati, data analyst, data analytics portfolio, business intelligence, machine learning, Python, SQL, Power BI, Tableau, NLP" name="keywords">
+  <meta property="og:title" content="Shrut Prajapati | Data Analytics Portfolio">
+  <meta property="og:description" content="Explore analytics, machine learning, visualization, and business intelligence projects by Shrut Prajapati.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://shrut1261.github.io/analyst/">
+  <meta property="og:image" content="https://shrut1261.github.io/analyst/assets/img/Shrut.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Shrut Prajapati | Data Analytics Portfolio">
+  <meta name="twitter:description" content="Analytics portfolio highlighting machine learning, BI dashboards, NLP, and statistical analysis projects.">
+  <link rel="canonical" href="https://shrut1261.github.io/analyst/">
 
   <!-- Favicons -->
   <link href="assets/img/icon13.png" rel="icon">
@@ -58,7 +67,7 @@
     <section id="hero" class="hero section light-background">
 
       <img src="assets/img/Shrut.jpg" alt="">
-      <img src="assets/img/Shrut5.jpg" alt=""> 
+      <img src="assets/img/Shrut5.JPG" alt="Shrut Prajapati portrait"> 
 
       <div class="container" data-aos="zoom-out">
         <div class="row justify-content-center">
@@ -66,7 +75,7 @@
             <h2>Shrut Prajapati</h2>
             <p><span class="typed" data-typed-items=" Master's in Data Analytics, Computer Engineer, Software Developer, Freelancer">Designer</span><span class="typed-cursor typed-cursor--blink" aria-hidden="true"></span></p>
             <div class="social-links">
-              <a href="https://github.com/Shrut1261"><i class="bi bi-git hub-x"></i></a>
+              <a href="https://github.com/Shrut1261" aria-label="GitHub profile"><i class="bi bi-github"></i></a>
               <a href="https://www.linkedin.com/in/shrutp/"><i class="bi bi-linkedin"></i></a>
               <a href="https://leetcode.com/u/Shrut_Prajapati/"><i class="bi bi-leetcode"></i></a>
               <a href="https://www.kaggle.com/shrutprajapati"><i class="bi bi-kaggle"></i></a>
@@ -448,18 +457,17 @@
         <li data-filter=".filter-ml">Machine Learning</li>
         <li data-filter=".filter-viz">Data Visualization</li>
         <li data-filter=".filter-nlp">NLP & Text Analysis</li>
-        <li data-filter=".filter-time-series">Time Series & Forecasting</li>
         <li data-filter=".filter-eda">EDA & Statistical Analysis</li>
       </ul><!-- End Portfolio Filters -->
 
       <div class="row gy-4 isotope-container" data-aos="fade-up" data-aos-delay="200">
 
         <!-- NASA Metadata -->
-        <div class="col-lg-4 col-md-6 portfolio-item isotope-item filter-app">
+        <div class="col-lg-4 col-md-6 portfolio-item isotope-item filter-eda">
           <img src="assets/img/masonry-portfolio/NASA.png" class="img-fluid" alt="NASA Metadata">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">NASA Metadata</h4>
-            <p style="color: #fff;">Analyzing NASA Metadata</p>
+            <p style="color: #fff;">Exploratory analysis of NASA metadata to surface patterns, data quality signals, and research-ready insights.</p>
             <a href="https://github.com/Shrut1261/Analyzing-NASA-Metadata" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -471,7 +479,7 @@
           <img src="assets/img/masonry-portfolio/Predicative .png" class="img-fluid" alt="Predictive Analysis">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">Predictive Analysis</h4>
-            <p style="color: #fff;">Machine Learning Models</p>
+            <p style="color: #fff;">Machine learning workflow for estimating alumni giving rates and supporting fundraising decisions.</p>
             <a href="https://github.com/Shrut1261/Predicting-Alumni-Giving-Rates" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -479,11 +487,11 @@
         </div>
 
         <!-- Twitter Data Analysis -->
-        <div class="col-lg-4 col-md-6 portfolio-item isotope-item filter-social">
+        <div class="col-lg-4 col-md-6 portfolio-item isotope-item filter-nlp filter-eda">
           <img src="assets/img/masonry-portfolio/tweeter Analysis.png" class="img-fluid" alt="Twitter Data Analysis">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">Twitter Data Analysis</h4>
-            <p style="color: #fff;">Exploring Twitter Trends & Sentiment</p>
+            <p style="color: #fff;">Social text analysis exploring Twitter trends, engagement themes, and sentiment signals.</p>
             <a href="https://github.com/Shrut1261/Twitter" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -495,7 +503,7 @@
           <img src="assets/img/masonry-portfolio/Orange.png" class="img-fluid" alt="Orange Data Analysis">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">Orange Data Analysis</h4>
-            <p style="color: #fff;">Data Mining with Orange</p>
+            <p style="color: #fff;">Visual data mining project using Orange to prepare data, test models, and compare analytic outcomes.</p>
             <a href="https://github.com/Shrut1261/Orange" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -507,7 +515,7 @@
           <img src="assets/img/masonry-portfolio/Tableau .png" class="img-fluid" alt="Tableau Dashboard">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">Tableau Dashboard</h4>
-            <p style="color: #fff;">Interactive Data Visualization</p>
+            <p style="color: #fff;">Interactive Tableau dashboard focused on clear KPI storytelling and decision-ready visuals.</p>
             <a href="https://github.com/Shrut1261/Tableau-" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -519,7 +527,7 @@
           <img src="assets/img/masonry-portfolio/20 Newgroup .png" class="img-fluid" alt="20 Newsgroups">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">20 Newsgroups</h4>
-            <p style="color: #fff;">Text Classification & NLP</p>
+            <p style="color: #fff;">Text classification project applying NLP preprocessing and modeling to the 20 Newsgroups dataset.</p>
             <a href="https://github.com/Shrut1261/20_newsgroups" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -531,7 +539,7 @@
           <img src="assets/img/masonry-portfolio/Behaviour Analysis .png" class="img-fluid" alt="Behavior Analysis">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">Behavior Analysis</h4>
-            <p style="color: #fff;">Analyzing User Behavior Data</p>
+            <p style="color: #fff;">Statistical analysis of user behavior data to identify usage patterns and actionable segments.</p>
             <a href="https://github.com/Shrut1261/Behavior-Analysis-" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -539,11 +547,11 @@
         </div>
         
         <!-- Credit Card Churn Prediction -->
-        <div class="col-lg-4 col-md-6 portfolio-item isotope-item filter-ml filter-time-series">
+        <div class="col-lg-4 col-md-6 portfolio-item isotope-item filter-ml">
           <img src="assets/img/masonry-portfolio/icon52.png" class="img-fluid" alt="Credit Card Churn Prediction">
           <div class="portfolio-info" style="background: rgba(0,0,0,0.6); color: #fff;">
             <h4 style="color: #fff;">Credit Card Churn Prediction</h4>
-            <p style="color: #fff;">Predicting customer churn using machine learning techniques.</p>
+            <p style="color: #fff;">Classification model for identifying credit card customers at risk of churn and prioritizing retention actions.</p>
             <a href="https://github.com/Shrut1261/credit-card-churn-prediction" title="Go to Repository" class="details-link">
               <i class="bi bi-box-arrow-up-right" style="font-size: 1rem; color: #fff;"></i>
             </a>
@@ -563,7 +571,7 @@
       <!-- Section Title --> 
 <div class="container section-title" data-aos="fade-up">
   <h2>Areas of Interest</h2>
-  <p> look at some of the things I love working on.</p>
+  <p>Explore some of the areas I love working on.</p>
 </div><!-- End Section Title -->
 <div class="container">
   <div class="row gy-4">
@@ -654,7 +662,7 @@
         <a href="https://www.ibm.com/analytics" class="stretched-link">
           <h3>Data Analytics</h3>
         </a>
-        <p>Hove telling a story. Making a beautiful and compelling presentation is one of my favorite skills.</p>
+        <p>I love telling a story with data. Making a clear and compelling presentation is one of my favorite skills.</p>
       </div>
     </div><!-- End Service Item -->
 
@@ -753,7 +761,7 @@
       <h3 class="sitename">Shrut Prajapati</h3>
       <p>Always evolving, seeking new horizons, embracing challenges, and finding peace in the process.</p>
       <div class="social-links d-flex justify-content-center">
-        <a href="https://github.com/Shrut1261"><i class="bi bi-git hub-x"></i></a>
+        <a href="https://github.com/Shrut1261" aria-label="GitHub profile"><i class="bi bi-github"></i></a>
         <a href="https://www.facebook.com/share/1ApUyrnH1a/?mibextid=wwXIfr"><i class="bi bi-facebook"></i></a>
         <a href="https://www.instagram.com/_shrut_prajapati_/"><i class="bi bi-instagram"></i></a>
         <a href="https://www.linkedin.com/in/shrutp/"><i class="bi bi-linkedin"></i></a>


### PR DESCRIPTION
## Summary

- Add a professional README with portfolio overview, tech stack, local run instructions, featured projects, and an upgrade roadmap.
- Polish `index.html` with stronger SEO/social metadata, clearer project descriptions, spelling fixes, a GitHub icon fix, and portfolio filter alignment.

## Impact

This makes the repository easier to evaluate from GitHub and improves the live portfolio's discoverability, project clarity, and filter behavior without deleting any files.

## Validation

- Confirmed the working tree is clean after two commits.
- Reviewed the `index.html` diff and verified stale filter classes such as `filter-app`, `filter-social`, and `filter-time-series` no longer remain.
- Confirmed the branch contains the two requested commits: README first, portfolio polish second.

Note: A local Python static-server smoke test was not run because the environment's `python`/`py` commands resolve to the Windows Store launcher and timed out.