### PR TITLE
[codex] Restore smoky hero and polish about section

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -533,12 +533,13 @@ section,
   height: 100%;
   object-fit: cover;
   object-position: center center;
+  filter: saturate(0.92) brightness(1.04) contrast(0.96);
   z-index: 1;
 }
 
 .hero:before {
   content: "";
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.62) 42%, rgba(255, 255, 255, 0.16) 100%);
+  background: linear-gradient(90deg, rgba(239, 248, 253, 0.86) 0%, rgba(226, 241, 249, 0.66) 43%, rgba(80, 92, 106, 0.28) 100%);
   position: absolute;
   inset: 0;
   z-index: 2;

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <meta property="og:description" content="Explore analytics, machine learning, visualization, and business intelligence projects by Shrut Prajapati.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://shrut1261.github.io/analyst/">
-  <meta property="og:image" content="https://shrut1261.github.io/analyst/assets/img/hero-beach-profile.jpg">
+  <meta property="og:image" content="https://shrut1261.github.io/analyst/assets/img/Shrut.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Shrut Prajapati | Data Analytics Portfolio">
   <meta name="twitter:description" content="Analytics portfolio highlighting machine learning, BI dashboards, NLP, and statistical analysis projects.">
@@ -66,8 +66,7 @@
     <!-- Hero Section -->
     <section id="hero" class="hero section light-background">
 
-      <img src="assets/img/Shrut.jpg" alt="">
-      <img src="assets/img/Shrut5.jpg" alt=""> 
+      <img src="assets/img/Shrut.jpg" alt="Shrut Prajapati by the ocean">
 
       <div class="container" data-aos="zoom-out">
         <div class="row justify-content-center">


### PR DESCRIPTION
## Summary

- Restore the first hero section to the close-up ocean image (`assets/img/Shrut.jpg`) the site previously used.
- Remove the extra broken `Shrut5.jpg` hero image tag so the top-left broken image icon disappears.
- Add a subtle smoky overlay/filter treatment so the hero keeps the same feel while looking cleaner and more polished.
- Polish the About section with cleaner professional copy, a tighter heading, balanced image styling, and improved text readability.
- Update Open Graph image metadata back to the same ocean hero image.

## Validation

- Ran `git diff --check`.
- Confirmed the hero markup now references one image only.
- Confirmed only one About section marker remains in `index.html`.

Note: Automated browser preview was attempted locally, but this session does not have Playwright installed.